### PR TITLE
Fix performance bottleneck on benchmark

### DIFF
--- a/src/art.rs
+++ b/src/art.rs
@@ -276,3 +276,9 @@ impl ArtKey for std::string::String {
         self.as_bytes()
     }
 }
+
+impl ArtKey for std::vec::Vec<u8> {
+    fn bytes(&self) -> &[u8] {
+        self.as_slice()
+    }
+}

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -53,8 +53,12 @@ mod bench {
                 b.iter(|| {
                     let mut t = $mapty::new();
                     for i in 0..$n {
-                        let s = rng.gen_ascii_chars().take($len).collect::<String>();
-                        test::black_box(t.insert(s, i));
+                        // use Vec instead of Str to avoid utf-8 overhead
+                        let mut v = Vec::with_capacity($len);
+                        for ch in rng.gen_ascii_chars().take(20) {
+                            v.push(ch as u8);
+                        }
+                        test::black_box(t.insert(v, i));
                     }
                 })
             }

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,7 +1,6 @@
 
 #[cfg(test)]
 mod bench {
-
     use ArtTree;
     use rand;
     use test;
@@ -11,307 +10,107 @@ mod bench {
     use test::Bencher;
     use rand::Rng;
 
-    const N: u32 = 100000;
+    const N: usize = 100_000;
+    const N_STR_20: usize = 40_000;
+    const N_STR_100: usize = 7_000;
+    const N_STR_1000: usize = 1_000;
+    const N_SEARCH: u64 = 100_000;
 
-    #[bench]
-    fn bench_insert_art_u64(b: &mut Bencher) {
-        type InsrtType = u64;
-        let mut rng = rand::thread_rng();
+    macro_rules! bench_num {
+        ($name: ident, $ty: ident, $mapty: ident, $n: expr) => {
+            #[bench]
+            fn $name(b: &mut Bencher) {
+                let mut rng = rand::thread_rng();
 
-        b.iter(|| {
-            let mut t = ArtTree::new();
-            for _ in 0..N {
-                test::black_box(t.insert(rng.gen::<InsrtType>(),rng.gen::<InsrtType>()));
+                b.iter(|| {
+                    let mut t = $mapty::new();
+                    for _ in 0..$n {
+                        test::black_box(t.insert(rng.gen::<$ty>(), rng.gen::<$ty>()));
+                    }
+                })
             }
-        })
-    }
-
-    #[bench]
-    fn bench_insert_btree_u64(b: &mut Bencher) {
-        type InsrtType = u64;
-        let mut rng = rand::thread_rng();
-
-        b.iter(|| {
-            let mut t = BTreeMap::new();
-            for _ in 0..N {
-                test::black_box(t.insert(rng.gen::<InsrtType>(),rng.gen::<InsrtType>()));
-            }
-        })
-    }
-
-    #[bench]
-    fn bench_insert_hmap_u64(b: &mut Bencher) {
-        type InsrtType = u64;
-        let mut rng = rand::thread_rng();
-
-        b.iter(|| {
-            let mut t = HashMap::new();
-            for _ in 0..N {
-                test::black_box(t.insert(rng.gen::<InsrtType>(),rng.gen::<InsrtType>()));
-            }
-        })
-    }
-
-    #[bench]
-    fn bench_insert_art_u32(b: &mut Bencher) {
-        type InsrtType = u32;
-        let mut rng = rand::thread_rng();
-
-        b.iter(|| {
-            let mut t = ArtTree::new();
-            for _ in 0..N {
-                test::black_box(t.insert(rng.gen::<InsrtType>(),rng.gen::<InsrtType>()));
-            }
-        })
-    }
-
-    #[bench]
-    fn bench_insert_btree_u32(b: &mut Bencher) {
-        type InsrtType = u32;
-        let mut rng = rand::thread_rng();
-
-        b.iter(|| {
-            let mut t = BTreeMap::new();
-            for _ in 0..N {
-                test::black_box(t.insert(rng.gen::<InsrtType>(),rng.gen::<InsrtType>()));
-            }
-        })
-    }
-
-    #[bench]
-    fn bench_insert_hmap_u32(b: &mut Bencher) {
-        type InsrtType = u32;
-        let mut rng = rand::thread_rng();
-
-        b.iter(|| {
-            let mut t = HashMap::new();
-            for _ in 0..N {
-                test::black_box(t.insert(rng.gen::<InsrtType>(),rng.gen::<InsrtType>()));
-            }
-        })
-    }
-
-    #[bench]
-    fn bench_insert_art_len_20_rnd_string(b: &mut Bencher) {
-        let mut rng = rand::thread_rng();
-
-        b.iter(|| {
-            let mut t = ArtTree::new();
-            for i in 0..40000 {
-                let s = rng.gen_ascii_chars().take(20).collect::<String>();
-                test::black_box(t.insert(s, i));
-            }
-        })
-    }
-
-    #[bench]
-    fn bench_insert_btree_len_20_rnd_string(b: &mut Bencher) {
-        let mut rng = rand::thread_rng();
-
-        b.iter(|| {
-            let mut t = BTreeMap::new();
-            for i in 0..40000 {
-                let s = rng.gen_ascii_chars().take(20).collect::<String>();
-                test::black_box(t.insert(s, i));
-            }
-        })
-    }
-
-    #[bench]
-    fn bench_insert_hmap_len_20_rnd_string(b: &mut Bencher) {
-        let mut rng = rand::thread_rng();
-
-        b.iter(|| {
-            let mut t = HashMap::new();
-            for i in 0..40000 {
-                let s = rng.gen_ascii_chars().take(20).collect::<String>();
-                test::black_box(t.insert(s, i));
-            }
-        })
-    }
-
-    #[bench]
-    fn bench_insert_art_len_100_rnd_string(b: &mut Bencher) {
-        let mut rng = rand::thread_rng();
-
-        b.iter(|| {
-            let mut t = ArtTree::new();
-            for i in 0..7000 {
-                let s = rng.gen_ascii_chars().take(100).collect::<String>();
-                test::black_box(t.insert(s, i));
-            }
-        })
-    }
-
-    #[bench]
-    fn bench_insert_btree_len_100_rnd_string(b: &mut Bencher) {
-        let mut rng = rand::thread_rng();
-
-        b.iter(|| {
-            let mut t = BTreeMap::new();
-            for i in 0..7000 {
-                let s = rng.gen_ascii_chars().take(100).collect::<String>();
-                test::black_box(t.insert(s, i));
-            }
-        })
-    }
-
-    #[bench]
-    fn bench_insert_hmap_len_100_rnd_string(b: &mut Bencher) {
-        let mut rng = rand::thread_rng();
-
-        b.iter(|| {
-            let mut t = HashMap::new();
-            for i in 0..7000 {
-                let s = rng.gen_ascii_chars().take(100).collect::<String>();
-                test::black_box(t.insert(s, i));
-            }
-        })
-    }
-
-    #[bench]
-    fn bench_insert_art_len_1000_rnd_string(b: &mut Bencher) {
-        let mut rng = rand::thread_rng();
-
-        b.iter(|| {
-            let mut t = ArtTree::new();
-            for i in 0..1000 {
-                let s = rng.gen_ascii_chars().take(1000).collect::<String>();
-                test::black_box(t.insert(s, i));
-            }
-        })
-    }
-
-    #[bench]
-    fn bench_insert_btree_len_1000_rnd_string(b: &mut Bencher) {
-        let mut rng = rand::thread_rng();
-
-        b.iter(|| {
-            let mut t = BTreeMap::new();
-            for i in 0..1000 {
-                let s = rng.gen_ascii_chars().take(1000).collect::<String>();
-                test::black_box(t.insert(s, i));
-            }
-        })
-    }
-
-    #[bench]
-    fn bench_insert_hmap_len_1000_rnd_string(b: &mut Bencher) {
-        let mut rng = rand::thread_rng();
-
-        b.iter(|| {
-            let mut t = HashMap::new();
-            for i in 0..1000 {
-                let s = rng.gen_ascii_chars().take(1000).collect::<String>();
-                test::black_box(t.insert(s, i));
-            }
-        })
-    }
-
-    #[bench]
-    fn bench_search_art_seq_u64(b: &mut Bencher) {
-        let num_insert = 100000u64;
-        let mut t = ArtTree::new();
-
-        for i in 0..num_insert {
-            t.insert(i, i);
         }
-
-        b.iter(|| {
-            for i in 0..num_insert {
-                test::black_box( t.get(&i) );
-            }
-        })
     }
 
-    #[bench]
-    fn bench_search_btree_seq_u64(b: &mut Bencher) {
-        let num_insert = 100000u64;
-        let mut t = BTreeMap::new();
+    bench_num!(bench_insert_art_u64, u64, ArtTree, N);
+    bench_num!(bench_insert_btree_u64, u64, BTreeMap, N);
+    bench_num!(bench_insert_hmap_u64, u64, HashMap, N);
 
-        for i in 0..num_insert {
-            t.insert(i, i);
+    bench_num!(bench_insert_art_u32, u32, ArtTree, N);
+    bench_num!(bench_insert_btree_u32, u32, BTreeMap, N);
+    bench_num!(bench_insert_hmap_u32, u32, HashMap, N);
+
+    macro_rules! bench_str {
+        ($name: ident, $len: expr, $mapty: ident, $n: expr) => {
+            #[bench]
+            fn $name(b: &mut Bencher) {
+                let mut rng = rand::thread_rng();
+
+                b.iter(|| {
+                    let mut t = $mapty::new();
+                    for i in 0..$n {
+                        let s = rng.gen_ascii_chars().take($len).collect::<String>();
+                        test::black_box(t.insert(s, i));
+                    }
+                })
+            }
         }
-
-        b.iter(|| {
-            for i in 0..10 * num_insert {
-                let k = i % num_insert;
-                test::black_box( t.get(&k) );
-            }
-        })
     }
 
-    #[bench]
-    fn bench_search_hmap_seq_u64(b: &mut Bencher) {
-        let num_insert = 100000u64;
-        let mut t = HashMap::new();
+    bench_str!(bench_insert_art_20_rnd_str, 20, ArtTree, N_STR_20);
+    bench_str!(bench_insert_btree_20_rnd_str, 20, BTreeMap, N_STR_20);
+    bench_str!(bench_insert_hmap_20_rnd_str, 20, HashMap, N_STR_20);
 
-        for i in 0..num_insert {
-            t.insert(i, i);
+    bench_str!(bench_insert_art_100_rnd_str, 100, ArtTree, N_STR_100);
+    bench_str!(bench_insert_btree_100_rnd_str, 100, BTreeMap, N_STR_100);
+    bench_str!(bench_insert_hmap_100_rnd_str, 100, HashMap, N_STR_100);
+
+    bench_str!(bench_insert_art_1000_rnd_str, 1000, ArtTree, N_STR_1000);
+    bench_str!(bench_insert_btree_1000_rnd_str, 1000, BTreeMap, N_STR_1000);
+    bench_str!(bench_insert_hmap_1000_rnd_str, 1000, HashMap, N_STR_1000);
+
+    macro_rules! bench_search_seq {
+        ($name: ident, $mapty: ident, $n: expr) => {
+            #[bench]
+            fn $name(b: &mut Bencher) {
+                let mut t = $mapty::new();
+
+                for i in 0..$n {
+                    t.insert(i, i);
+                }
+
+                b.iter(|| for i in 0..$n {
+                    test::black_box(t.get(&i));
+                })
+            }
         }
-
-        b.iter(|| {
-            for i in 0..10 * num_insert {
-                let k = i % num_insert;
-                test::black_box( t.get(&k) );
-            }
-        })
     }
 
-    #[bench]
-    fn bench_search_art_rnd_u64(b: &mut Bencher) {
-        type InsrtType = u64;
-        let mut rng = rand::thread_rng();
-        let num_insert = 100000u64;
-        let mut t = ArtTree::new();
+    bench_search_seq!(bench_search_art_seq_u64, ArtTree, N_SEARCH);
+    bench_search_seq!(bench_search_btree_seq_u64, BTreeMap, N_SEARCH);
+    bench_search_seq!(bench_search_hmap_seq_u64, HashMap, N_SEARCH);
 
-        for i in 0..num_insert {
-            t.insert(rng.gen::<InsrtType>(), i);
+    macro_rules! bench_search_rnd {
+        ($name: ident, $mapty: ident, $n: expr) => {
+            #[bench]
+            fn $name(b: &mut Bencher) {
+                type InsrtType = u64;
+                let mut rng = rand::thread_rng();
+                let mut t = $mapty::new();
+
+                for i in 0..$n {
+                    t.insert(rng.gen::<InsrtType>(), i);
+                }
+
+                b.iter(|| for i in 0..10 * $n {
+                    let k = i % $n;
+                    test::black_box(t.get(&k));
+                })
+            }
         }
-
-        b.iter(|| {
-            for i in 0..10 * num_insert {
-                let k = i % num_insert;
-                test::black_box( t.get(&k) );
-            }
-        })
     }
 
-    #[bench]
-    fn bench_search_btree_rnd_u64(b: &mut Bencher) {
-        type InsrtType = u64;
-        let mut rng = rand::thread_rng();
-        let num_insert = 100000u64;
-        let mut t = BTreeMap::new();
-
-        for i in 0..num_insert {
-            t.insert(rng.gen::<InsrtType>(), i);
-        }
-
-        b.iter(|| {
-            for i in 0..10 * num_insert {
-                let k = i % num_insert;
-                test::black_box( t.get(&k) );
-            }
-        })
-    }
-
-    #[bench]
-    fn bench_search_hmap_rnd_u64(b: &mut Bencher) {
-        type InsrtType = u64;
-        let mut rng = rand::thread_rng();
-        let num_insert = 100000u64;
-        let mut t = HashMap::new();
-
-        for i in 0..num_insert {
-            t.insert(rng.gen::<InsrtType>(), i);
-        }
-
-        b.iter(|| {
-            for i in 0..10 * num_insert {
-                let k = i % num_insert;
-                test::black_box( t.get(&k) );
-            }
-        })
-    }
+    bench_search_rnd!(bench_search_art_rnd_u64, ArtTree, N_SEARCH);
+    bench_search_rnd!(bench_search_btree_rnd_u64, BTreeMap, N_SEARCH);
+    bench_search_rnd!(bench_search_hmap_rnd_u64, HashMap, N_SEARCH);
 }

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -16,11 +16,15 @@ mod bench {
     const N_STR_1000: usize = 1_000;
     const N_SEARCH: u64 = 100_000;
 
+    fn new_rng() -> rand::XorShiftRng {
+        rand::XorShiftRng::new_unseeded()
+    }
+
     macro_rules! bench_num {
         ($name: ident, $ty: ident, $mapty: ident, $n: expr) => {
             #[bench]
             fn $name(b: &mut Bencher) {
-                let mut rng = rand::thread_rng();
+                let mut rng = new_rng();
 
                 b.iter(|| {
                     let mut t = $mapty::new();
@@ -44,7 +48,7 @@ mod bench {
         ($name: ident, $len: expr, $mapty: ident, $n: expr) => {
             #[bench]
             fn $name(b: &mut Bencher) {
-                let mut rng = rand::thread_rng();
+                let mut rng = new_rng();
 
                 b.iter(|| {
                     let mut t = $mapty::new();
@@ -95,7 +99,7 @@ mod bench {
             #[bench]
             fn $name(b: &mut Bencher) {
                 type InsrtType = u64;
-                let mut rng = rand::thread_rng();
+                let mut rng = new_rng();
                 let mut t = $mapty::new();
 
                 for i in 0..$n {


### PR DESCRIPTION
I tried to cleanup benchmark code, and shave some overhead that is not related to data structures.
 - Clean up benchmark code with macros and consts
 - Use XorShiftRng instead of thread_rng, which is faster and deterministic.
 - Change String to Vec<u8>, which should give same results for each data structures. Constructing Vec<u8> is much cheaper than String because Rust String needs an extra calculation UTF-8 validation. Also uses with_capacity() instead of collect(), which reduces memory allocation caused by buffer resizing.

before
```
$ cargo bench
   Compiling art v0.1.0 (file:///home/yjh0502/repo/git/ArtTree)
    Finished release [optimized] target(s) in 6.2 secs
     Running target/release/deps/art-a315e05db900bbaf

running 21 tests
test bench::bench::bench_insert_art_len_1000_rnd_string   ... bench:  42,450,417 ns/iter (+/- 1,557,903)
test bench::bench::bench_insert_art_len_100_rnd_string    ... bench:  34,051,892 ns/iter (+/- 796,406)
test bench::bench::bench_insert_art_len_20_rnd_string     ... bench:  54,533,373 ns/iter (+/- 1,002,201)
test bench::bench::bench_insert_art_u32                   ... bench:  26,527,038 ns/iter (+/- 1,806,945)
test bench::bench::bench_insert_art_u64                   ... bench:  30,681,753 ns/iter (+/- 1,129,419)
test bench::bench::bench_insert_btree_len_1000_rnd_string ... bench:  41,386,161 ns/iter (+/- 111,107)
test bench::bench::bench_insert_btree_len_100_rnd_string  ... bench:  35,947,975 ns/iter (+/- 277,836)
test bench::bench::bench_insert_btree_len_20_rnd_string   ... bench:  62,120,743 ns/iter (+/- 685,137)
test bench::bench::bench_insert_btree_u32                 ... bench:  23,803,864 ns/iter (+/- 183,533)
test bench::bench::bench_insert_btree_u64                 ... bench:  28,162,813 ns/iter (+/- 355,500)
test bench::bench::bench_insert_hmap_len_1000_rnd_string  ... bench:  41,805,358 ns/iter (+/- 84,059)
test bench::bench::bench_insert_hmap_len_100_rnd_string   ... bench:  33,440,761 ns/iter (+/- 272,043)
test bench::bench::bench_insert_hmap_len_20_rnd_string    ... bench:  50,518,336 ns/iter (+/- 903,199)
test bench::bench::bench_insert_hmap_u32                  ... bench:  16,807,355 ns/iter (+/- 286,077)
test bench::bench::bench_insert_hmap_u64                  ... bench:  19,023,666 ns/iter (+/- 499,562)
test bench::bench::bench_search_art_rnd_u64               ... bench:  61,168,162 ns/iter (+/- 13,680,195)
test bench::bench::bench_search_art_seq_u64               ... bench:   6,261,751 ns/iter (+/- 423,354)
test bench::bench::bench_search_btree_rnd_u64             ... bench:  27,038,648 ns/iter (+/- 35,145)
test bench::bench::bench_search_btree_seq_u64             ... bench:  80,660,886 ns/iter (+/- 480,733)
test bench::bench::bench_search_hmap_rnd_u64              ... bench:  43,767,141 ns/iter (+/- 245,012)
test bench::bench::bench_search_hmap_seq_u64              ... bench:  52,985,405 ns/iter (+/- 717,343)

test result: ok. 0 passed; 0 failed; 0 ignored; 21 measured

```

after
```
$ cargo bench
    Finished release [optimized] target(s) in 0.0 secs
     Running target/release/deps/art-a315e05db900bbaf

running 21 tests
test bench::bench::bench_insert_art_1000_rnd_str   ... bench:   1,855,701 ns/iter (+/- 130,305)
test bench::bench::bench_insert_art_100_rnd_str    ... bench:   4,559,853 ns/iter (+/- 349,051)
test bench::bench::bench_insert_art_20_rnd_str     ... bench:  21,458,012 ns/iter (+/- 958,960)
test bench::bench::bench_insert_art_u32            ... bench:  22,279,996 ns/iter (+/- 4,363,856)
test bench::bench::bench_insert_art_u64            ... bench:  23,274,810 ns/iter (+/- 1,397,472)
test bench::bench::bench_insert_btree_1000_rnd_str ... bench:     585,022 ns/iter (+/- 5,371)
test bench::bench::bench_insert_btree_100_rnd_str  ... bench:   4,078,027 ns/iter (+/- 39,537)
test bench::bench::bench_insert_btree_20_rnd_str   ... bench:  29,241,780 ns/iter (+/- 410,627)
test bench::bench::bench_insert_btree_u32          ... bench:  19,871,270 ns/iter (+/- 183,885)
test bench::bench::bench_insert_btree_u64          ... bench:  21,526,949 ns/iter (+/- 216,056)
test bench::bench::bench_insert_hmap_1000_rnd_str  ... bench:     484,700 ns/iter (+/- 7,443)
test bench::bench::bench_insert_hmap_100_rnd_str   ... bench:   2,739,932 ns/iter (+/- 52,738)
test bench::bench::bench_insert_hmap_20_rnd_str    ... bench:  17,483,848 ns/iter (+/- 459,348)
test bench::bench::bench_insert_hmap_u32           ... bench:  12,361,467 ns/iter (+/- 318,740)
test bench::bench::bench_insert_hmap_u64           ... bench:  12,715,853 ns/iter (+/- 310,442)
test bench::bench::bench_search_art_rnd_u64        ... bench:  68,919,512 ns/iter (+/- 3,652,568)
test bench::bench::bench_search_art_seq_u64        ... bench:   6,993,965 ns/iter (+/- 537,857)
test bench::bench::bench_search_btree_rnd_u64      ... bench:  27,704,435 ns/iter (+/- 38,993)
test bench::bench::bench_search_btree_seq_u64      ... bench:   8,091,358 ns/iter (+/- 264,220)
test bench::bench::bench_search_hmap_rnd_u64       ... bench:  46,673,854 ns/iter (+/- 281,649)
test bench::bench::bench_search_hmap_seq_u64       ... bench:   6,144,797 ns/iter (+/- 74,108)

test result: ok. 0 passed; 0 failed; 0 ignored; 21 measured
```